### PR TITLE
Added transit parameter parser

### DIFF
--- a/lib/transit/rails/railtie.rb
+++ b/lib/transit/rails/railtie.rb
@@ -3,7 +3,7 @@ require 'rails/railtie'
 module Transit
   module Rails
     class Railtie < ::Rails::Railtie
-      config.after_initialize do
+      config.before_initialize do
         require 'transit/rails/renderer'
         require 'action_controller/metal/renderers'
 
@@ -11,9 +11,22 @@ module Transit
         Mime::Type.register_alias "application/transit+json", :transit_verbose
         Mime::Type.register "application/transit+msgpack", :transit_msgpack
 
+      end
+
+      config.after_initialize do
         ActionController.add_renderer :transit do |obj, options|
           Transit::Rails::Renderer.new(obj, options).render
         end
+      end
+
+      initializer "transit.configure_rails_initialization" do |app|
+        require 'transit/rails/reader'
+        app.middleware.swap("ActionDispatch::ParamsParser",
+                            "ActionDispatch::ParamsParser", {
+                              Mime::TRANSIT => Transit::Rails::Reader.make_reader(:json),
+                              Mime::TRANSIT_VERBOSE => Transit::Rails::Reader.make_reader(:json_verbose),
+                              Mime::TRANSIT_MSGPACK => Transit::Rails::Reader.make_reader(:msgpack)
+                            })
       end
     end
   end

--- a/lib/transit/rails/reader.rb
+++ b/lib/transit/rails/reader.rb
@@ -1,0 +1,16 @@
+require 'transit'
+require 'transit/reader'
+
+module Transit
+  module Rails
+    class Reader
+      
+      def self.make_reader (format)
+        Proc.new do |raw_post|
+          Transit::Reader.new(format, raw_post).read
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Should now automatically parse parameters using transit when the content type is matches one of the transit mime-types.
