### PR TITLE
Access MIME types by correct keys

### DIFF
--- a/lib/transit/rails/railtie.rb
+++ b/lib/transit/rails/railtie.rb
@@ -21,8 +21,8 @@ module Transit
 
       initializer "transit.configure_rails_initialization" do |app|
         require 'transit/rails/reader'
-        parameter_parsers = { Mime[:TRANSIT] => Transit::Rails::Reader.make_reader(:json),
-                              Mime[:TRANSIT_MSGPACK] => Transit::Rails::Reader.make_reader(:msgpack) }
+        parameter_parsers = { Mime[:transit] => Transit::Rails::Reader.make_reader(:json),
+                              Mime[:transit_msgpack] => Transit::Rails::Reader.make_reader(:msgpack) }
         if ActionDispatch::Request.respond_to?(:parameter_parsers=)
           ActionDispatch::Request.parameter_parsers = (ActionDispatch::Request.parameter_parsers || {}).merge(parameter_parsers)
         else


### PR DESCRIPTION
The keys used to register the Transit MIME types in the Mime hash are
lowercase, not uppercase, but the initializer was using uppercase
symbols to look them up. This lookup doesn't succeed and so Transit
parameters were not getting correctly parsed.

```
[1] pry(main)> Mime::Type.register "application/transit+json", :transit
=> [#<Proc:0x007ff1cb784028@/Users/eli/.gem/ruby/2.2.2/gems/actionpack-4.2.5.2/lib/abstract_controller/collector.rb:19>]
[2] pry(main)> Mime[:TRANSIT]
=> nil
[3] pry(main)> Mime[:transit]
=> #<Mime::Type:0x007ff1d32d93b8 @hash=-363482929724082868, @string="application/transit+json", @symbol=:transit, @synonyms=[]>
```
